### PR TITLE
bugfix: redirect to trick details page instead of comments index when…

### DIFF
--- a/src/Controller/CommentController.php
+++ b/src/Controller/CommentController.php
@@ -77,7 +77,7 @@ class CommentController extends AbstractController
                 'Your comment has been succesfully edited!'
             );
 
-            return $this->redirectToRoute('app_comment_index', [], Response::HTTP_SEE_OTHER);
+            return $this->redirectToRoute('app_trick_show', ['slug' => $trick->getSlug()], Response::HTTP_SEE_OTHER);
         }
 
         return $this->renderForm('comment/edit.html.twig', [


### PR DESCRIPTION
… submitting the edit comment form